### PR TITLE
Remove validateIndentation config

### DIFF
--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -73,6 +73,5 @@
   "requireSpaceBeforeBlockStatements": true,
   "requireSpaceBeforeObjectValues": true,
   "requireSpaceBetweenArguments": true,
-  "validateIndentation": 2,
   "validateParameterSeparator": ", "
 }


### PR DESCRIPTION
There is currently a known bug with the `validateIndentation` property which prevents jscs from running when using this config: https://github.com/jscs-dev/node-jscs/issues/857 and https://github.com/jscs-dev/node-jscs/issues/933

I've removed this option until the issues are fixed in node-jscs.
